### PR TITLE
[macOS] Fix 10 sec delay between auto-syncs (Nagle’s Algorithm + Delayed ACK, App Nap)

### DIFF
--- a/haveclip-core.pro
+++ b/haveclip-core.pro
@@ -87,6 +87,22 @@ HEADERS  += \
     src/Helpers/qmlnode.h \
     src/ConfigMigrations/V3Migration.h
 
+mac {
+    CONFIG += objective_c
+
+    # https://doc.qt.io/qt-5.12/qmake-variable-reference.html#objective-sources   #objective-headers
+    # OBJECTIVE_SOURCES is obsolete since Qt5.6 (QTBUG-36575)
+    # - https://codereview.qt-project.org/c/qt/qtbase/+/77117/  (Branch 5.6, "INCLUDED IN" button)
+    # - before Qt5.6 it only shows the warning:
+    #   - https://github.com/qt/qtbase/commit/9ff1310af51814e521572fa3de4e086907633a90#diff-b42d489993899e48fa93c92b344e9201
+    #   - https://codereview.qt-project.org/c/qt/qtbase/+/77117/13/mkspecs/features/mac/objective_c.prf#b4
+    #
+    SOURCES           += src/darwin/AppNapPreventingActivity.mm
+    OBJECTIVE_HEADERS += src/darwin/AppNapPreventingActivity.h
+
+    LIBS += -framework Foundation
+}
+
 OTHER_FILES += \
     TODO \
     LICENSE \

--- a/src/ClipboardManager.cpp
+++ b/src/ClipboardManager.cpp
@@ -437,6 +437,8 @@ void ClipboardManager::clipboardTracking()
 
 #elif defined(Q_OS_MAC)
 		// There's no notification about clipboard changes on OS X, active checking is needed
+		m_macAppNapPreventingActivity.begin();
+
 		m_macTrackingTimer = new QTimer(this);
 		connect(m_macTrackingTimer, SIGNAL(timeout()), this, SLOT(clipboardChanged()));
 		m_macTrackingTimer->start(1000);
@@ -452,6 +454,8 @@ void ClipboardManager::clipboardTracking()
 #elif defined(Q_OS_MAC)
 		if (m_macTrackingTimer)
 		{
+			m_macAppNapPreventingActivity.end();
+
 			m_macTrackingTimer->stop();
 			m_macTrackingTimer->deleteLater();
 			m_macTrackingTimer = 0;

--- a/src/ClipboardManager.h
+++ b/src/ClipboardManager.h
@@ -31,6 +31,10 @@
 #include "ClipboardItem.h"
 #include "History.h"
 
+#ifdef Q_OS_MAC
+#include "darwin/AppNapPreventingActivity.h"
+#endif
+
 class History;
 class Node;
 class RemoteControl;
@@ -86,6 +90,7 @@ private:
 
 #if defined(Q_OS_MAC)
 	QTimer *m_macTrackingTimer;
+	AppNapPreventingActivity m_macAppNapPreventingActivity;
 #endif
 
 #ifdef Q_WS_X11

--- a/src/Network/ConnectionManager.cpp
+++ b/src/Network/ConnectionManager.cpp
@@ -151,6 +151,7 @@ void ConnectionManager::syncClipboard(ClipboardItem *it)
 		// - https://stackoverflow.com/questions/46249616/qtcpsocket-setting-lowdelayoption-seems-to-have-no-effect#comment79463584_46249616
 		// - https://doc.qt.io/qt-5.12/qsslsocket.html#flush
 		d->setSocketOption(QAbstractSocket::LowDelayOption, 1);  // TCP_NODELAY
+		// But, really it's caused by App Nap (macOS) - see "haveclip-core/src/darwin/AppNapPreventingActivity.mm"
 
 		connect(d, SIGNAL(untrustedCertificateError(Node,QList<QSslError>)), this, SIGNAL(untrustedCertificateError(Node,QList<QSslError>)));
 		connect(d, SIGNAL(sslFatalError(QList<QSslError>)), this, SIGNAL(sslFatalError(QList<QSslError>)));

--- a/src/darwin/AppNapPreventingActivity.h
+++ b/src/darwin/AppNapPreventingActivity.h
@@ -1,0 +1,36 @@
+#ifndef APPNAPPREVENTINGACTIVITY_H
+#define APPNAPPREVENTINGACTIVITY_H
+
+#ifndef __OBJC__ //or `_OBJC_NSOBJECT_H_`
+//#include <QtGlobal>
+
+#ifdef Q_FORWARD_DECLARE_OBJC_CLASS
+Q_FORWARD_DECLARE_OBJC_CLASS(NSObject); // not to conflict with declaration in QDEBUG_H
+#else
+class NSObject; //or `typedef struct objc_object NSObject;` - see Q_FORWARD_DECLARE_OBJC_CLASS
+#endif
+
+#endif
+
+
+class AppNapPreventingActivity
+{
+	NSObject *activity;
+
+	//NOTE: if access outside of ClipboardManager::clipboardTracking() is needed then:
+	//       - remove `friend ...`
+	//       - uncomment `public:`
+	//       - pass `reason` string to `begin(const QString &reason){... reason:reason.toNSString() ...}`
+	//       - add additional checks (activity != nil)
+	//       - call end() from destructor
+	friend class ClipboardManager;
+//public:
+	explicit AppNapPreventingActivity() = default;
+	//Q_DISABLE_COPY(AppNapPreventingActivity); // delete or not delete...
+	//void *operator new(std::size_t) = delete; // delete or not delete...
+
+	void begin();
+	void end();
+};
+
+#endif // APPNAPPREVENTINGACTIVITY_H

--- a/src/darwin/AppNapPreventingActivity.mm
+++ b/src/darwin/AppNapPreventingActivity.mm
@@ -1,0 +1,68 @@
+//// Disabling App Nap stuff
+//
+// Didn't work (in Terminal):
+//  defaults write cz.havefun.HaveClip NSAppSleepDisabled -bool YES
+//  defaults write cz.havefun.HaveClip LSAppNapIsDisabled -bool YES
+//
+//
+// Links (App Nap):
+//
+// - Pure solution in C (don't need Objective-C compiler)
+//   https://stackoverflow.com/questions/22784886/what-can-make-nanosleep-drift-with-exactly-10-sec-on-mac-os-x-10-9/22785076#22785076
+//
+// - Keep-alive timers on sockets that weren't firing every 5 seconds with App Nap
+//   https://github.com/robbiehanson/CocoaAsyncSocket/issues/276#issuecomment-59842364
+//
+// - `beginActivityWithOptions:reason:` documentation
+//   https://developer.apple.com/documentation/foundation/nsprocessinfo/1415995-beginactivitywithoptions
+//
+// - What App Nap does & how it works
+//   https://developer.apple.com/library/archive/documentation/Performance/Conceptual/power_efficiency_guidelines_osx/AppNap.html
+//
+// - QTimer and App Nap (add `LIBS += -framework Foundation` and `CONFIG += objective_c` to ".pro" file)
+//   https://forum.qt.io/post/213085
+//   - solution (AppNapSuspender class) doesn't work since it doesn't use ARC nor manual retain/release -> activity is "autorelease"ed after 3-4 minutes
+//     ARC solution: https://stackoverflow.com/questions/19847293/disable-app-nap-in-macos-10-9-mavericks-application  #20100906
+//
+// - It would be nice if Qt Support disabling App Nap (Utility class to wrap AppNap activities)
+//   https://bugreports.qt.io/browse/QTBUG-43861?focusedCommentId=296871#comment-296871
+//   https://codereview.qt-project.org/c/qt/qtmacextras/+/106306
+//   (see `ActivityOption` in "qmacactivity.h" and `NSActivityOptions` enum in "qmacactivity.mm")
+//   - Automatic & Sudden Termination
+//     https://developer.apple.com/library/archive/documentation/General/Conceptual/MOSXAppProgrammingGuide/CoreAppDesign/CoreAppDesign.html#//apple_ref/doc/uid/TP40010543-CH3-SW22
+//
+// - About plist key (Terminal commands above)
+//   https://github.com/performancecopilot/pcp/issues/20
+//   https://github.com/bitcoin/bitcoin/issues/11896
+//   https://git.gnu.io/gnu/emacs/commit/04a7977f700fc46cf29d5a41bc7dcffef71044c6
+//
+// - Some more examples
+//   - manual retain/release with ARC, `id` vs `id<NSObject>` vs `NSObject*`
+//     https://github.com/krab/bitcoin/blob/1e0f3c44992fb82e6bf36c2ef9277b0759c17c4c/src/qt/macos_appnap.mm#L20-L53
+//     from https://github.com/bitcoin/bitcoin/pull/12783
+//   - [retain] https://github.com/blundering/iTerm2-snippets/commit/b9d98c44e281c9be9ee080a7c32726e562f2fe8a
+//
+//
+// Memory Management in Objective-C:
+// - autorelease/retain/release
+//   https://stackoverflow.com/questions/7076247/retain-release-of-returned-objects
+// - Qt doesn't use Automated Reference Counting (ARC)
+//   https://wiki.qt.io/Apple_Platforms_Coding_Conventions#ARC_.28Automated_Reference_Counting.29
+
+
+#import <Foundation/NSProcessInfo.h>
+#include "AppNapPreventingActivity.h"
+
+void AppNapPreventingActivity::begin()
+{
+	activity = [[[NSProcessInfo processInfo] beginActivityWithOptions:
+		NSActivityUserInitiatedAllowingIdleSystemSleep & ~NSActivitySuddenTerminationDisabled
+		reason: @"Clipboard tracking initiated."]
+	retain];
+}
+
+void AppNapPreventingActivity::end()
+{
+	[[NSProcessInfo processInfo] endActivity: activity];
+	[activity release];
+}


### PR DESCRIPTION
## Issue

Case:

- **problem** (macOS → Win):
  1. copy (**macOS** v10.14, HaveClip v0.14)
  2. paste (Windows, HaveClip v0.13)
- ok (Win → macOS):
  1. copy (Windows, HaveClip v0.13)
  2. paste (**macOS** v10.14, HaveClip v0.14)

At first, it looked like the HaveClip copies (synchronizes) every other time. I'd been having to copy the same thing several times:

1. macOS: copy, copy [, copy]
2. Windows: paste

But the first copy (after HaveClip launch) is always fine.

I wanted to find out on which side (macOS or Win) the problem occurs, i.e. do _network packets_ reach Windows?

1. I started [Process Explorer](https://docs.microsoft.com/en-us/sysinternals/downloads/process-explorer) (Win)
2. went to "Performance Graph" tab in Properties of `haveclip.exe` process
3. copied (macOS)

Nothing. I had already started thinking about ... until I saw the receive of _packet_:

![I/O Bytes History: 10 sec delay; on macOS side: HaveClip restart, first copy — ok, …, copy — delay](https://user-images.githubusercontent.com/66136696/121034954-4255a980-c7cf-11eb-8597-b6eb836f078b.png)<!-- delay-process_explorer.png -->

So, the _packets_ reach, but with the **10 second delay** and the **problem is on macOS side** (I checked this by opening the "Network" tab of `Activity Monitor.app` — the network activity graph is similar to Process Explorer graph, i.e. the moments of packet transmission and reception coincide).

## locating a bug and searching for a solution
**The first guess.** It is related to [TCP Performance problems caused by interaction between Nagle’s Algorithm and Delayed ACK](http://www.stuartcheshire.org/papers/NagleDelayedAck/):

> In this document I describe my latest encounter with this bad interaction between Nagle’s Algorithm and Delayed ACK: a testing program used in WiFi conformance testing. This program tests the speed of a WiFi implementation by repeatedly sending 100,000 bytes of data over TCP and then waiting for an application-layer ack from the other to confirm its reception. Windows achieved the 3.5Mb/s required to pass the test; Mac OS X got just 2.7Mb/s and failed. The naive (and wrong) conclusion would be that Windows is fast, and Mac OS X is slow, and that’s that. The truth is not so simple. The true explanation was that the test was flawed, and Mac OS X happened to expose the problem, while Windows, basically through luck, did not.
> 
> Engineers found that reducing the buffer size from 100,000 bytes to 99,912 bytes made the measured speed jump to 5.2Mb/s, easily passing the test. At 99,913 bytes the test got 2.7Mb/s and failed. Clearly what’s going on here is more interesting than just a slow wireless card and/or driver […](http://www.stuartcheshire.org/papers/NagleDelayedAck/)

The _10 second delay_ in our case is orders of magnitude greater than the delay ([100-200 ms](http://www.stuartcheshire.org/papers/NagleDelayedAck/)) that the Nagle’s Algorithm + Delayed ACK can cause. However, let's run the test with the Nagle's algorithm [disabled](https://en.wikipedia.org/wiki/Nagle%27s_algorithm?oldid=1000860850#Negative_effect_on_larger_writes).

Test: set the `TCP_NODELAY` socket option (*"[Fix 10 sec delay between auto-syncs> disable Nagle’s Algorithm](https://github.com/aither64/haveclip-core/pull/1/commits/d03e878289036956c95fa94bb7ab456fba2387be)"* commit) and repeat the previous test (with Process Explorer).

Result: better!<sup>*[why?]*</sup> The delay is gone … but after some time of idle, it comes back.

**The second guess.** It is caused by App Nap. After opening the "Energy" tab of `Activity Monitor.app`, I see that App Nap switches from "No" to "Yes".

The moment of switching:
![after App Nap is activated, the 10 sec delay appears](https://user-images.githubusercontent.com/66136696/121035703-f5be9e00-c7cf-11eb-9344-f5b962d7c7ff.png)<!-- delay-disable_nagle-process_explorer-activity_monitor.png -->

The second commit *"[Fix 10 sec delay between auto-syncs> \[macOS\] disable App Nap](https://github.com/aither64/haveclip-core/pull/1/commits/33392f74efe18800f05fa4f937cfa479c77ac1e2)"* completely eliminates the _10 second delay_ problem.

**Note:** I work on different things (different areas of knowledge) so I always keep references (on the basis of which the decision was made) to quickly "restore context" in the future.

<details><summary>Based on … (the to read before modify list)</summary>

_A copy of the references from comments in the code._

App Nap:

- [Pure solution in C (no Objective-C compiler needed)](https://stackoverflow.com/questions/22784886/what-can-make-nanosleep-drift-with-exactly-10-sec-on-mac-os-x-10-9/22785076#22785076)
- [Keep-alive timers on sockets that weren’t firing every 5 seconds with App Nap](https://github.com/robbiehanson/CocoaAsyncSocket/issues/276#issuecomment-59842364)
- [`beginActivityWithOptions:reason:` documentation](https://developer.apple.com/documentation/foundation/nsprocessinfo/1415995-beginactivitywithoptions)
- [What App Nap does & how it works](https://developer.apple.com/library/archive/documentation/Performance/Conceptual/power_efficiency_guidelines_osx/AppNap.html)
- [QTimer and App Nap](https://forum.qt.io/post/213085) (add `LIBS += -framework Foundation` and `CONFIG += objective_c` to ".pro" file)
  - solution (AppNapSuspender class) doesn't work since it doesn't use ARC nor manual retain/release → activity is "autorelease"ed after 3‑4 minutes  
    [ARC solution](https://stackoverflow.com/questions/19847293/disable-app-nap-in-macos-10-9-mavericks-application) (in [comment](https://stackoverflow.com/questions/19847293/disable-app-nap-in-macos-10-9-mavericks-application#20100906))
- [It would be nice if Qt Support disabling App Nap](https://bugreports.qt.io/browse/QTBUG-43861?focusedCommentId=296871#comment-296871) (Utility class to wrap AppNap activities)  
  [(see `ActivityOption` in "qmacactivity.h" and `NSActivityOptions` enum in "qmacactivity.mm")](https://codereview.qt-project.org/c/qt/qtmacextras/+/106306)
  - [Automatic & Sudden Termination](https://developer.apple.com/library/archive/documentation/General/Conceptual/MOSXAppProgrammingGuide/CoreAppDesign/CoreAppDesign.html#//apple_ref/doc/uid/TP40010543-CH3-SW22)
- About plist keys  
  Didn’t work (in Terminal):
  ```bash
  defaults write cz.havefun.HaveClip NSAppSleepDisabled -bool YES
  defaults write cz.havefun.HaveClip LSAppNapIsDisabled -bool YES
  ```
  - performancecopilot/pcp#20
  - bitcoin/bitcoin#11896
  - https://git.gnu.io/gnu/emacs/commit/04a7977f700fc46cf29d5a41bc7dcffef71044c6
- Some more examples
  - [manual retain/release with ARC](https://github.com/krab/bitcoin/blob/1e0f3c44992fb82e6bf36c2ef9277b0759c17c4c/src/qt/macos_appnap.mm#L20-L53), `id` vs `id<NSObject>` vs `NSObject*`  
    from bitcoin/bitcoin#12783
  - `[retain]` blundering/iTerm2-snippets@b9d98c44e281c9be9ee080a7c32726e562f2fe8a

Memory Management in Objective-C:

- [autorelease/retain/release](https://stackoverflow.com/questions/7076247/retain-release-of-returned-objects)
- [Qt doesn’t use Automated Reference Counting (ARC)](https://wiki.qt.io/Apple_Platforms_Coding_Conventions#ARC_.28Automated_Reference_Counting.29)

qmake (".pro" file):

- [`OBJECTIVE_SOURCES`,](https://doc.qt.io/qt-5.12/qmake-variable-reference.html#objective-sources) [`OBJECTIVE_HEADERS`](https://doc.qt.io/qt-5.12/qmake-variable-reference.html#objective-headers)  
  `OBJECTIVE_SOURCES` is obsolete since Qt5.6 ([QTBUG-36575](https://codereview.qt-project.org/c/qt/qtbase/+/77117/): Branch 5.6, "INCLUDED IN" button),  
  before Qt5.6 it only shows the warning:
  - https://git.sailfishos.org/mer-core/qtbase/commit/9ff1310af51814e521572fa3de4e086907633a90#d3f63b68f1cab108e699dad6a6cc2c3797a6ebf3
  - https://codereview.qt-project.org/c/qt/qtbase/+/77117/13/mkspecs/features/mac/objective_c.prf#b4
</details>

## …It works fine now

So, after I have:

1. [setup dev environment](https://gist.github.com/shoogle/750a330c851bd1a924dfe1346b0b4a08):
   1. installed Command Line Tools: `xcode-select --install` (since qt/qtbase@fa7626713b3a943609453459190e16c49d61dfd3)
   2. setup Qt 5 […](https://gist.github.com/shoogle/750a330c851bd1a924dfe1346b0b4a08#step-3---make-sure-qt-creator-uses-the-correct-c-compiler) […](https://doc.qt.io/qt-5/macos.html)
      - [Can’t skip login in Qt installer?](https://superuser.com/questions/1524977/cant-skip-login-in-qt-installer) — Qt v5.12.* is the [latest LTS Qt release](https://www.qt.io/blog/qt-offering-changes-2020) that can be installed w/o a Qt account (simply disconnect from a LAN/Wi-Fi network before installation)
      - 5.12.* Offline Installers:
        - https://www.qt.io/offline-installers
          - http://download.qt.io/official_releases/qt/5.12/5.12.8/qt-opensource-mac-x64-5.12.8.dmg
          - http://download.qt.io/official_releases/qt/5.12/5.12.8/qt-opensource-mac-x64-5.12.8.dmg.mirrorlist
        - http://master.qt.io/archive/qt/5.12/5.12.8/
   3. installed OpenSSL from Homebrew
2. made N fixes — just to _build_ w/o errors and _run_ w/o "segmentation faults" current version (0.15.0) of HaveClip
3. applied this fix
4. made other M fixes

It works fine now <sup>2020-07-07</sup> with Qt v5.12.8 and OpenSSL v1.1.1g on macOS Mojave.