### PR TITLE
OpenSSl related fixes, Part 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 src/git_version.h
+/libs.pri

--- a/haveclip-core.pro
+++ b/haveclip-core.pro
@@ -112,16 +112,35 @@ OTHER_FILES += \
     doc/protocol.md \
     CHANGELOG
 
-unix {
+unix:!mac {
 	CONFIG += link_pkgconfig
 	PKGCONFIG += openssl
 
 	!packagesExist(sailfishapp) {
-		!mac {
 		PKGCONFIG += x11
 			LIBS += -lX11
-		}
 	}
+}
+
+mac {
+    #> brew info openssl
+    # openssl@1.1 is keg-only, which means it was not symlinked into /usr/local,
+    # because macOS provides LibreSSL.
+    #
+    # For compilers to find openssl@1.1 you may need to set:
+    #  export LDFLAGS="-L/usr/local/opt/openssl@1.1/lib"
+    #  export CPPFLAGS="-I/usr/local/opt/openssl@1.1/include"
+
+    # Don't `ln -s`!: https://medium.com/@timmykko/using-openssl-library-with-macos-sierra-7807cfd47892
+    #                 https://stackoverflow.com/questions/38670295/homebrew-refusing-to-link-openssl#comment64722608_38670295
+
+    # https://github.com/openssl/openssl/blob/OpenSSL_1_1_1/NOTES.UNIX
+
+    INCLUDEPATH += /usr/local/opt/openssl/include
+
+    # for application (haveclip-desktop.pro, ...)
+    # https://doc.qt.io/qt-5.12/qmake-advanced-usage.html#library-dependencies
+    LIBS += -L/usr/local/opt/openssl/lib -lcrypto
 }
 
 GITVERSION = src/git_version.h

--- a/haveclip-core.pro
+++ b/haveclip-core.pro
@@ -112,35 +112,78 @@ OTHER_FILES += \
     doc/protocol.md \
     CHANGELOG
 
-unix:!mac {
-	CONFIG += link_pkgconfig
-	PKGCONFIG += openssl
+#================== Libs ==================
+# How to set library paths (OpenSSL)?
+# Several ways (by priority) to do this (with examples):
+# 1. In "Projects" mode [ctrl+5] >
+#        Build & Run > Build >
+#         Build Settings (Edit build configuration: "Debug", "Profile", "Release") >
+#          Build Step: qmake / Additional arguments:
+#          ( https://doc.qt.io/qtcreator/creator-build-settings.html#qmake-build-steps )
+#          - OPENSSL_ROOT="/usr/local/opt/openssl"
+#          - OPENSSL_ROOT="" INCLUDEPATH+="/usr/local/opt/openssl/include" LIBS+="-L/usr/local/opt/openssl/lib -lcrypto"
+#            (you can specify OPENSSL_ROOT empty to manually set INCLUDEPATH and LIBS)
+# 2. Create file "libs.pri" and specify the paths to all libraries in it.
+#    (see example below)
+#    Note[for Git]: "libs.pri" is included in ".gitignore".
+# 3. Add "pkgconfig" path (macOS, Homebrew: "/usr/local/bin") to PATH environment variable:
+#    https://doc.qt.io/qtcreator/creator-project-settings-environment.html
+#    ("Append Path..." [Finder: Shift+⌘+G] or "Edit")
+#    or directly set a path to the "pkgconfig" through "Additional arguments" (see way 1)
+#       PKG_CONFIG=/usr/local/bin/pkg-config
+#       ( https://stackoverflow.com/questions/16972066/using-pkg-config-with-qt-creator-qmake-on-mac-osx/51602580#51602580 )
+# Note: "by priority" means that you can set the paths, for example, in (2) and (1), and (1) will shadow (2).
+# Note: if you prefer to use CPLUS_INCLUDE_PATH (CPATH, ...) and LIBRARY_PATH environment variables
+#       instead of INCLUDEPATH and LIBS qmake variables
+#       then specify OPENSSL_ROOT="" and LIBS+="-lcrypto" by (1) or (2) way.
 
-	!packagesExist(sailfishapp) {
-		PKGCONFIG += x11
-			LIBS += -lX11
-	}
+exists(libs.pri):include(libs.pri)
+# "libs.pri" file contents example:
+#  !defined(OPENSSL_ROOT, var): OPENSSL_ROOT="/usr/local/opt/openssl"
+# or
+#  !defined(OPENSSL_ROOT, var) {
+#      OPENSSL_ROOT=""
+#      # https://github.com/openssl/openssl/blob/OpenSSL_1_1_1/NOTES.UNIX
+#      INCLUDEPATH += /usr/local/opt/openssl/include
+#      # for application (haveclip-desktop.pro, ...)
+#      # https://doc.qt.io/qt-5.12/qmake-advanced-usage.html#library-dependencies
+#      LIBS += -L/usr/local/opt/openssl/lib -lcrypto
+#  }
+# or
+#  !defined(OPENSSL_ROOT, var) {
+#      # for use with CPATH (CPLUS_INCLUDE_PATH, ...) and LIBRARY_PATH environment variables
+#      OPENSSL_ROOT=""
+#      # for application (haveclip-desktop.pro, ...)
+#      # https://doc.qt.io/qt-5.12/qmake-advanced-usage.html#library-dependencies
+#      LIBS += -lcrypto
+#  }
+
+defined(OPENSSL_ROOT, var) {
+    !isEmpty(OPENSSL_ROOT) {
+        INCLUDEPATH += $$OPENSSL_ROOT/include
+        LIBS += -L$$OPENSSL_ROOT/lib -lcrypto
+    }
+} else:unix {
+    CONFIG *= link_pkgconfig
+    PKGCONFIG += openssl
 }
 
-mac {
-    #> brew info openssl
-    # openssl@1.1 is keg-only, which means it was not symlinked into /usr/local,
-    # because macOS provides LibreSSL.
-    #
-    # For compilers to find openssl@1.1 you may need to set:
-    #  export LDFLAGS="-L/usr/local/opt/openssl@1.1/lib"
-    #  export CPPFLAGS="-I/usr/local/opt/openssl@1.1/include"
+# Note[darwin, macOS, Homebrew]: Where is OpenSSL located?
+# See `brew info openssl` output in Terminal:
+#   openssl@1.1 is keg-only, which means it was not symlinked into /usr/local,
+#   because macOS provides LibreSSL.
+#
+#   For compilers to find openssl@1.1 you may need to set:
+#    export LDFLAGS="-L/usr/local/opt/openssl@1.1/lib"
+#    export CPPFLAGS="-I/usr/local/opt/openssl@1.1/include"
+#
+# Don't `ln -s`!: https://medium.com/@timmykko/using-openssl-library-with-macos-sierra-7807cfd47892
+#                 https://stackoverflow.com/questions/38670295/homebrew-refusing-to-link-openssl#comment64722608_38670295
 
-    # Don't `ln -s`!: https://medium.com/@timmykko/using-openssl-library-with-macos-sierra-7807cfd47892
-    #                 https://stackoverflow.com/questions/38670295/homebrew-refusing-to-link-openssl#comment64722608_38670295
-
-    # https://github.com/openssl/openssl/blob/OpenSSL_1_1_1/NOTES.UNIX
-
-    INCLUDEPATH += /usr/local/opt/openssl/include
-
-    # for application (haveclip-desktop.pro, ...)
-    # https://doc.qt.io/qt-5.12/qmake-advanced-usage.html#library-dependencies
-    LIBS += -L/usr/local/opt/openssl/lib -lcrypto
+unix:!darwin:!packagesExist(sailfishapp) {
+    CONFIG *= link_pkgconfig
+    PKGCONFIG += x11
+         LIBS += -lX11
 }
 
 GITVERSION = src/git_version.h

--- a/haveclip-core.pro
+++ b/haveclip-core.pro
@@ -2,7 +2,9 @@ QT       += core gui network
 
 TARGET = haveclipcore
 TEMPLATE = lib
-CONFIG += staticlib
+CONFIG += staticlib create_prl
+# Note: add `CONFIG += link_prl` to an app:
+#       https://doc.qt.io/qt-5.12/qmake-advanced-usage.html#library-dependencies
 
 packagesExist(sailfishapp) {
 	DEFINES += MER_SAILFISH

--- a/src/CertificateGeneratorThread.cpp
+++ b/src/CertificateGeneratorThread.cpp
@@ -41,7 +41,13 @@ CertificateGeneratorThread::~CertificateGeneratorThread()
 
 	CRYPTO_cleanup_all_ex_data();
 
+#ifndef OPENSSL_NO_CRYPTO_MDEBUG
+	// Time to retired crypto-mdebug
+	//   https://github.com/openssl/openssl/pull/10572
+	// - https://github.com/openssl/openssl/pull/10572/files#diff-0ad35796f3b4040e66893ac4cb4b6b28R282-R331
+	// - https://github.com/openssl/openssl/pull/10572/files#diff-a88baedd3b3f460db4620f1794f6ef48R334
 	CRYPTO_mem_leaks(m_bio);
+#endif
 	BIO_free(m_bio);
 }
 


### PR DESCRIPTION
**Note:** Each section below describes a single commit (or group of commits).

## Move to the tandem of [`create_prl` (lib) + `link_prl` (app)](https://doc.qt.io/qt-5.12/qmake-advanced-usage.html#library-dependencies)

For setting the path to OpenSSL (`LIBS`) in one place (in haveclip-core project). This will come in handy for the next commit.

## Support for multiple ways to set the path to OpenSSL

**One of the reasons.**  
What will a newbie (new to macOS Dev and Qt Dev) get [after](https://github.com/aither64/haveclip-core/pull/1#issue-663633829)<sup>[section "…It works fine now"]</sup> he <sup>(the versions I have installed are shown in parentheses)</sup> :

1. install Command Line Tools <sup>(version: `pkgutil —pkg-info=com.apple.pkg.CLTools_Executables` ⇒ 10.3.0…; `xcrun --show-sdk-version` ⇒ 10.14… → macOS Mojave)</sup>
2. setup Qt <sup>(version: Qt 5.12.8; Qt Creator 4.11.2)</sup>
3. try to build <sup><kbd><kbd>⌘</kbd><kbd>B</kbd></kbd></sup> "haveclip-desktop"? <sup>(version: 0.15.0, commit aither64/haveclip-desktop@fa5b6e857f37c71f7fa81cd3ebf541087533ee3d)</sup>

"Compile Output" will be something like this (for the sake of shortening, some parts of the lines have been replaced by "..."):

<pre><samp>…
<em>00:25:56: Starting: "…/make" -f …/Makefile qmake_all</em>
cd haveclip-core/ && …/qmake -o Makefile …/haveclip-core.pro …
<strong>Project ERROR: openssl development package not found</strong>
make: * [sub-haveclip-core-qmake_all] Error 3
<em>00:25:56: The process "/Library/Developer/CommandLineTools/usr/bin/make" exited with code 2.</em>
Error while building/deploying project haveclip-desktop (kit: Desktop Qt 5.12.8 clang 64bit)
When executing step "qmake"
</samp></pre>

Then he will try to install OpenSSL via _possibly_ Homebrew:

1. [install Homebrew](https://brew.sh/#install)
2. <details><summary>installing OpenSSL</summary>
   
   `brew install openssl`  
   ```
   …
   openssl@1.1 is keg-only, which means it was not symlinked into /usr/local,
   because macOS provides LibreSSL.
   
   If you need to have openssl@1.1 first in your PATH run:
     echo 'export PATH="/usr/local/opt/openssl@1.1/bin:$PATH"' >> ~/.zshrc
   
   For compilers to find openssl@1.1 you may need to set:
     export LDFLAGS="-L/usr/local/opt/openssl@1.1/lib"
     export CPPFLAGS="-I/usr/local/opt/openssl@1.1/include"
   
   ==> Summary
   🍺  /usr/local/Cellar/openssl@1.1/1.1.1g: 8,059 files, 18MB
   ```
   </details>

Of course, this will not help. The error will remain the same:
```
cd haveclip-core/ && …/qmake -o Makefile …/haveclip-core.pro …
Project ERROR: openssl development package not found
```

Next, he will _probably_ open the "haveclip-core.pro" file and see how OpenSSL is added to the project:
https://github.com/aither64/haveclip-core/blob/e0e22a3c29f21a6624671b943d3690f762cd579b/haveclip-core.pro#L98-L99

After that, he can go in different ways:
- <details><summary>directly set (hardcode) the paths to OpenSSL and remove the <em>pkg-config</em> (easy way)</summary>
  
  In "haveclip-core.pro":  
  ```qmake
  unix:!mac {
  	CONFIG += link_pkgconfig
  	PKGCONFIG += openssl
  
  	!packagesExist(sailfishapp) {
  		PKGCONFIG += x11
  		     LIBS += -lX11
  	}
  }
  
  mac: INCLUDEPATH += /usr/local/opt/openssl/include
  ```  
  In "haveclip-desktop.pro":  
  ```qmake
  unix:!mac {
      LIBS += -lX11
  
      CONFIG += link_pkgconfig
      PKGCONFIG += openssl
  }
  
  mac: LIBS += -L/usr/local/opt/openssl/lib -lcrypto
  ```  
  And it will work.
  </details>
- <details><summary>make the <em>pkg-config</em> work properly (this is not an easy way on macOS)</summary>
  
  Even if:
  
  1. `brew install pkg-config`
  2. add "/usr/local/bin" to PATH:
     - for applications launched via Dock, Launchpad, Spotlight, …:
       - Homebrew FAQ: [My Mac `.app`s don’t find `/usr/local/bin` utilities!](https://docs.brew.sh/FAQ#my-mac-apps-dont-find-usrlocalbin-utilities)  
         Note: it is more correct to use `$(launchctl getenv PATH)` instead of `$PATH` to preserve the _launchd_ original PATH.
     - for applications launched either via Dock, Launchpad, Spotlight, … or **via Terminal**:
       - Homebrew discussion: [Confused about setting $PATH](https://discourse.brew.sh/t/confused-about-setting-path/6317)  
         Note: [adding OpenSSL to PATH is a bad idea](https://stackoverflow.com/questions/38670295/homebrew-refusing-to-link-openssl#comment64722608_38670295) → [don’t link openssl](https://github.com/Homebrew/brew/pull/597) and don’t [`ln -s` it](https://medium.com/@timmykko/using-openssl-library-with-macos-sierra-7807cfd47892)!
       - "IntelliJ terminal PATH variable not the same with iTerm" [what does launchctl config user path do?](https://stackoverflow.com/questions/51636338/what-does-launchctl-config-user-path-do)
       - [osx-env-sync](https://github.com/ersiner/osx-env-sync)
       - [Setting environment variables in OS X for GUI applications](https://superuser.com/questions/476752/setting-environment-variables-in-os-x-for-gui-applications), [Set environment variable for the process before startup](https://stackoverflow.com/questions/16184505/set-environment-variable-for-the-process-before-startup) — breaks [code signature](https://developer.apple.com/library/archive/documentation/Security/Conceptual/CodeSigningGuide/AboutCS/AboutCS.html)!
       - [How do I set the global PATH environment variable on OS X?](https://serverfault.com/questions/16355/how-do-i-set-the-global-path-environment-variable-on-os-x) → [Setting environment variables via launchd.conf no longer works in OS X Yosemite/El Capitan/macOS Sierra/Mojave?](https://stackoverflow.com/questions/25385934/setting-environment-variables-via-launchd-conf-no-longer-works-in-os-x-yosemite/26586170#26586170)
       - Apple Developer Forums: [Setting PATH and other environment variables…](https://developer.apple.com/forums/thread/74371)
     - for [Qt Creator (Build Environment)](https://doc.qt.io/qtcreator/creator-project-settings-environment.html)  
       ("Append Path…" [Finder: <kbd><kbd>⇧</kbd><kbd>⌘</kbd><kbd>G</kbd></kbd>] or "Edit")
  3. or directly set a path to the _pkg-config_ — [`PKG_CONFIG=/usr/local/bin/pkg-config`](https://stackoverflow.com/questions/16972066/using-pkg-config-with-qt-creator-qmake-on-mac-osx/51602580#51602580)<sup>*hint*</sup>  
     Note: since different package managers use different installation paths (different prefixes: Homebrew stores packages in one place, MacPorts in another, and "another package manager" in a third), **instead of hardcoding** `PKG_CONFIG` in ".pro" file, it is better to set it through "[Additional arguments](https://doc.qt.io/qtcreator/creator-build-settings.html#qmake-build-steps)".
  
   
  …then the error will still remain:
  ```
  Project ERROR: openssl development package not found
  ```
  
  The error should <sup>(I didn't go this way)</sup> go away after adding `QT_CONFIG-=no-pkg-config`:
  
  - [Using pkg-config with Qt Creator/qmake on Mac OSX](https://stackoverflow.com/questions/16972066/using-pkg-config-with-qt-creator-qmake-on-mac-osx/16972067#16972067)  (support for _pkg-config_ is disabled by default in Qt for mac)
  - [Qt Creator on MacOS: pkg-config dependencies can’t be found](https://stackoverflow.com/questions/41593607/qt-creator-on-macos-pkg-config-dependencies-cant-be-found)
  - Qt commits:
    - [Do not unconditionally use pkg-config in .pro files](https://github.com/qt/qtbase/commit/638fc2e4c6751e6b98d18d14e149f172407205da)
    - [configure: add -pkg-config option to control pkg-config usage](https://github.com/qt/qtbase/commit/0991eae04871f1cb4a6d149658354bf129367074)
    - [Make the -pkg-config and -force-pkg-config options be the same](https://github.com/qt/qtbase/commit/5af7f7ec46d44c38f65a2727a744b3504e395aef)
    - [CMake: Don’t use libraries in /usr/local by default on macOS](https://github.com/qt/qtbase/commit/f3c7d22dd04afe8d889585fb5d6426f3d4591e74) ([see comment](https://github.com/qt/qtbase/commit/f3c7d22dd04afe8d889585fb5d6426f3d4591e74#diff-db5d371db80e3006d4f3cb88f8209da43e39238e190dbea2d98c5ca550be94aaR55-R67 "QtBuildInternalsConfig.cmake:55-67"))
  - Homebrew: [qt5: pkg-config is broken](https://github.com/Homebrew/legacy-homebrew/issues/27184)
  
   
  It can be added to ".pro" file: `contains(QT_CONFIG, no-pkg-config):!equals(PKG_CONFIG, "pkg-config"):!isEmpty(PKG_CONFIG): QT_CONFIG -= no-pkg-config` (Qt/qmake 4.8 compatible equivalent: `contains(QT_CONFIG, no-pkg-config){ !contains(PKG_CONFIG, pkg-config)|!count(PKG_CONFIG, 1){ !isEmpty(PKG_CONFIG): QT_CONFIG -= no-pkg-config } }`).
  </details>

**Another reason** is the ability to overwrite paths received from the _pkg-config_.

Also, when using `PKGCONFIG += openssl`, `-L/usr/local/opt/openssl/lib -lssl -lcrypto` is added to LIBS, but `-lssl` is not needed. HaveClip needs direct access to OpenSSL to generate certificates — for this purpose, it is enough to specify `-lcrypto`. So `PKGCONFIG += openssl` can be replaced with `PKGCONFIG += libcrypto` (see "[lib/pkgconfig](https://github.com/openssl/openssl/blob/OpenSSL_1_1_1g/Configurations/unix-Makefile.tmpl#L954-L1002)/[openssl.pc](https://github.com/openssl/openssl/blob/OpenSSL_1_1_1g/Configurations/unix-Makefile.tmpl#L999-L1002)" file).

P.S. The code from this commit can be used as a template that covers many use cases. Disadvantage: it uses the [`defined()`](https://doc.qt.io/qt-5.12/qmake-test-function-reference.html#defined-name-type) function → requires Qt/qmake 5 (`defined()` is [not available in Qt/qmake 4.8](https://doc.qt.io/archives/qt-4.8/qmake-function-reference.html)).

## Internal leak-checking funcs (crypto-mdebug) ~~is retired (deprecated)~~

[So](https://github.com/openssl/openssl/issues/8322#issuecomment-467107841)me OpenSSL builds are configured with the [`OPENSSL_NO_CRYPTO_MDEBUG`](https://github.com/openssl/openssl/blob/OpenSSL_1_1_1g/include/openssl/crypto.h#L291-L319) option.  
Which causes the errors:
```
haveclip-desktop-0.15/haveclip-core/src/CertificateGeneratorThread.cpp:44: error: use of undeclared identifier 'CRYPTO_mem_leaks'; did you mean 'CRYPTO_mem_ctrl'?
        CRYPTO_mem_leaks(m_bio);
        ^~~~~~~~~~~~~~~~
        CRYPTO_mem_ctrl
```
```
haveclip-desktop-0.15/haveclip-core/src/CertificateGeneratorThread.cpp:44:19: error: cannot initialize a parameter of type 'int' with an lvalue of type 'BIO *' (aka 'bio_st *')
        CRYPTO_mem_leaks(m_bio);
                         ^~~~~
/usr/local/opt/openssl/include/openssl/crypto.h:115:25: note: passing argument to parameter 'mode' here
int CRYPTO_mem_ctrl(int mode);
                        ^
```

[The "openssl/apps/openssl.c" file contains an example](https://github.com/openssl/openssl/blob/OpenSSL_1_1_1g/apps/openssl.c#L270-L273) of the correct use of `CRYPTO_mem_leaks()`.

See also:
- Deprecate most of debug-memory (openssl/openssl#10572).
- Time to retired crypto-mdebug (openssl/openssl#8322).