### PR TITLE
Fix `ConnectionManager::incomingConnection(int)` method signature mismatch

### DIFF
--- a/src/Network/ConnectionManager.cpp
+++ b/src/Network/ConnectionManager.cpp
@@ -219,7 +219,7 @@ void ConnectionManager::receiveEnabledChange(bool enabled)
 		stopReceiving();
 }
 
-void ConnectionManager::incomingConnection(int handle)
+void ConnectionManager::incomingConnection(qintptr handle)
 {
 	Receiver *c = new Receiver(this);
 	c->setSocketDescriptor(handle);

--- a/src/Network/ConnectionManager.h
+++ b/src/Network/ConnectionManager.h
@@ -102,7 +102,7 @@ private:
 private slots:
 	void hostAndPortChanged();
 	void receiveEnabledChange(bool enabled);
-	void incomingConnection(int handle);
+	void incomingConnection(qintptr handle);
 	void listenOnHost(const QHostInfo &m_host);
 	void introduceComplete(QString name, QSslCertificate cert);
 	void introduceFinish(Communicator::CommunicationStatus status);


### PR DESCRIPTION
## Issue

[The `ConnectionManager` class inherits from the `QTcpServer` class](https://github.com/aither64/haveclip-core/blob/v0.15.0/src/Network/ConnectionManager.h#L39), but the `ConnectionManager::incomingConnection(int)` method signature does not match the [`QTcpServer::incomingConnection(qintptr)` method signature](https://doc.qt.io/qt-5.12/qtcpserver.html#incomingConnection).

Compilation warning message:
```
haveclip-desktop-0.15/haveclip-core/src/Network/ConnectionManager.h:105:7:
 warning: 'ConnectionManager::incomingConnection' hides overloaded virtual function [-Woverloaded-virtual]
        void incomingConnection(int handle);
             ^
.../Qt/5.12.8/clang_64/lib/QtNetwork.framework/Headers/qtcpserver.h:94:18:
 note: hidden overloaded virtual function 'QTcpServer::incomingConnection' declared here:
       type mismatch at 1st parameter ('qintptr' (aka 'long long') vs 'int')
    virtual void incomingConnection(qintptr handle);
                 ^
```
**Note:** `int` size is [sometimes equals](https://www.viva64.com/en/t/0012/) to `long long` size (ILP64 and SILP64 [data model](https://en.wikipedia.org/wiki/64-bit_computing?oldid=975604853#64-bit_data_models))  and the methods signature will match, but mostly — not.
**Note:** [`qintptr` size](https://doc.qt.io/qt-5.12/qtglobal.html#qintptr-typedef) is [sometimes equals](https://www.viva64.com/en/t/0012/) to `int` size (and the methods signature will match), sometimes not.

As a result:
- `ConnectionManager::incomingConnection(int)` is not called,
- incoming connections (receiving a clipboard) are not processed.