### PR TITLE
OpenSSl related fixes, Part 2

### DIFF
--- a/src/CertificateGeneratorThread.cpp
+++ b/src/CertificateGeneratorThread.cpp
@@ -122,7 +122,12 @@ void CertificateGeneratorThread::generate()
 
 	X509_set_issuer_name(m_x509, name);
 
-	if (!addExtension(NID_basic_constraints, "critical,CA:FALSE,pathlen:0"))
+	// Reminder: don't set `NID_basic_constraints` to "CA:FALSE,pathlen:0":
+	// - these extension values are inconsistent (see RFC 5280, section 4.2.1.9 "Basic Constraints")
+	// - results in "pathlen:0" only
+	// => "Certificate does not exist or is not valid." (`ui->certInvalidLabel->show()`) on macOS (Secure Transport)
+	// More details in the commit message and PR...
+	if (!addExtension(NID_basic_constraints, "CA:FALSE"))
 		return error();
 
 	if (!addExtension(NID_subject_key_identifier, "hash"))

--- a/src/CertificateGeneratorThread.cpp
+++ b/src/CertificateGeneratorThread.cpp
@@ -174,7 +174,7 @@ void CertificateGeneratorThread::finish()
 		emit finished();
 }
 
-bool CertificateGeneratorThread::addExtension(int nid, char *value)
+bool CertificateGeneratorThread::addExtension(int nid, const char *value)
 {
 	X509_EXTENSION *ex;
 	X509V3_CTX ctx;

--- a/src/CertificateGeneratorThread.cpp
+++ b/src/CertificateGeneratorThread.cpp
@@ -64,7 +64,6 @@ void CertificateGeneratorThread::generate()
 	BIGNUM *e;
 	X509_NAME *name = NULL;
 	int bits = 2048;
-	long days = 10 * 365;
 
 	if ((m_pkey = EVP_PKEY_new()) == NULL)
 		return error();
@@ -94,7 +93,8 @@ void CertificateGeneratorThread::generate()
 	X509_set_version(m_x509, 2);
 	ASN1_INTEGER_set(X509_get_serialNumber(m_x509), 0);
 	X509_gmtime_adj(X509_get_notBefore(m_x509), 0);
-	X509_gmtime_adj(X509_get_notAfter(m_x509), 60 * 60 * 24 * days);
+	X509_gmtime_adj(X509_get_notAfter(m_x509), 1);  // or set notAfter to 99991231235959Z (GeneralizedTime)
+	                                                // https://tools.ietf.org/html/rfc5280#section-4.1.2.5
 	X509_set_pubkey(m_x509, m_pkey);
 
 	name = X509_get_subject_name(m_x509);

--- a/src/CertificateGeneratorThread.cpp
+++ b/src/CertificateGeneratorThread.cpp
@@ -133,7 +133,7 @@ void CertificateGeneratorThread::generate()
 	if (!addExtension(NID_subject_key_identifier, "hash"))
 		return error();
 
-	if (!X509_sign(m_x509, m_pkey, EVP_sha1()))
+	if (!X509_sign(m_x509, m_pkey, EVP_sha256()))
 		return error();
 
 	BN_clear_free(e);

--- a/src/CertificateGeneratorThread.h
+++ b/src/CertificateGeneratorThread.h
@@ -55,7 +55,7 @@ private:
 	X509 *m_x509;
 	EVP_PKEY *m_pkey;
 
-	bool addExtension(int nid, char *value);
+	bool addExtension(int nid, const char *value);
 	void error();
 };
 

--- a/src/Network/Communicator.cpp
+++ b/src/Network/Communicator.cpp
@@ -288,7 +288,7 @@ void Communicator::continueConversation()
 
 void Communicator::onError(QAbstractSocket::SocketError socketError)
 {
-	qDebug() << "Connection error" << socketError;
+	qDebug() << "Connection error" << socketError << ": " << errorString();
 
 	if(!m_conversation || (m_conversation && !m_conversation->isDone()))
 	{

--- a/src/Node.cpp
+++ b/src/Node.cpp
@@ -155,7 +155,12 @@ Node Node::load(QSettings *settings, unsigned int id)
 	QByteArray cert = settings->value("Certificate").toString().toUtf8();
 
 	if(!cert.isEmpty())
-		n.m_certificate = QSslCertificate::fromData(cert).first();
+	{
+		QList<QSslCertificate> certs = QSslCertificate::fromData(cert);
+
+		if(!certs.isEmpty())
+			n.m_certificate = certs.first();
+	}
 
 	return n;
 }


### PR DESCRIPTION
**Note:** Each section below describes a single commit (or group of commits).

## Basic Constraints extension values (CA:FALSE,pathlen:0) are inconsistent 

Starting with Qt 5.6, macOS native backend (Secure Transport) and some _Qt own code_ is used by default instead of OpenSSL:

- [forum.qt.io/topic/55853/openssl-and-mac-os-x/7](https://forum.qt.io/topic/55853/openssl-and-mac-os-x/7)
- [PKCS#12 import is not implemented](https://bugreports.qt.io/browse/QTBUG-56596?focusedCommentId=349207#comment-349207) (QTBUG-56596)

_Qt own code_ can't parse certs with **inconsistent extension values** (see RFC 5280, [section 4.2.1.9 "Basic Constraints"](https://tools.ietf.org/html/rfc5280#section-4.2.1.9)):

- HaveClip: [`SettingsDialog::showIdentity()`](https://github.com/aither64/haveclip-desktop/blob/v0.15.0/haveclip-desktop/src/SettingsDialog.cpp#L215), [`Settings::loadCertificate()`](https://github.com/aither64/haveclip-core/blob/v0.15.0/src/Settings.cpp#L739)
  - → [`QSslCertificate::fromPath()`](https://code.woboq.org/qt5/qtbase/src/network/ssl/qsslcertificate.cpp.html#_ZN15QSslCertificate8fromPathERK7QStringN4QSsl14EncodingFormatEN7QRegExp13PatternSyntaxE) [⎆](https://code.woboq.org/qt5/qtbase/src/network/ssl/qsslcertificate.cpp.html#510) 
  - → [`QSslCertificate::fromData()`](https://code.woboq.org/qt5/qtbase/src/network/ssl/qsslcertificate.cpp.html#_ZN15QSslCertificate8fromDataERK10QByteArrayN4QSsl14EncodingFormatE) [⎆](https://code.woboq.org/qt5/qtbase/src/network/ssl/qsslcertificate.cpp.html#567) 
    - → [`QSslCertificatePrivate::certificatesFromPem()`](https://code.woboq.org/qt5/qtbase/src/network/ssl/qsslcertificate_qt.cpp.html#_ZN22QSslCertificatePrivate19certificatesFromPemERK10QByteArrayi) [⎆](https://code.woboq.org/qt5/qtbase/src/network/ssl/qsslcertificate_qt.cpp.html#260) 
    - → [`QSslCertificatePrivate::certificatesFromDer()`](https://code.woboq.org/qt5/qtbase/src/network/ssl/qsslcertificate_qt.cpp.html#_ZN22QSslCertificatePrivate19certificatesFromDerERK10QByteArrayi) [⎆](https://code.woboq.org/qt5/qtbase/src/network/ssl/qsslcertificate_qt.cpp.html#273) → *QT_NO_OPENSSL* [⎆](https://code.woboq.org/qt5/qtbase/src/network/ssl/qsslcertificate_p.h.html#118)
      - → [`QSslCertificatePrivate::parse()`](https://code.woboq.org/qt5/qtbase/src/network/ssl/qsslcertificate_qt.cpp.html#_ZN22QSslCertificatePrivate5parseERK10QByteArray) [⎆](https://code.woboq.org/qt5/qtbase/src/network/ssl/qsslcertificate_qt.cpp.html#397) 
      - → [`QSslCertificatePrivate::parseExtension()`](https://code.woboq.org/qt5/qtbase/src/network/ssl/qsslcertificate_qt.cpp.html#_ZN22QSslCertificatePrivate14parseExtensionERK10QByteArrayP24QSslCertificateExtension) [●](https://code.woboq.org/qt5/qtbase/src/network/ssl/qsslcertificate_qt.cpp.html#501)..[●](https://code.woboq.org/qt5/qtbase/src/network/ssl/qsslcertificate_qt.cpp.html#511) (code.qt.io: [v5.15.0 ‑ L511](https://code.qt.io/cgit/qt/qtbase.git/tree/src/network/ssl/qsslcertificate_qt.cpp?h=v5.15.0#n511), [v5.12.8 ‑ L483](https://code.qt.io/cgit/qt/qtbase.git/tree/src/network/ssl/qsslcertificate_qt.cpp?h=v5.12.8#n483)) — see screenshot below
- ⇒ [`ui->certInvalidLabel->show()`](https://github.com/aither64/haveclip-desktop/blob/v0.15.0/haveclip-desktop/src/SettingsDialog.cpp#L221): **"[Certificate does not exist or is not valid.](https://github.com/aither64/haveclip-desktop/blob/v0.15.0/haveclip-desktop/src/SettingsDialog.ui#L395-L399)"**

![debugging QSslCertificatePrivate::parseExtension()](https://user-images.githubusercontent.com/66136696/122681523-7a6cdb80-d216-11eb-86f1-fb4465aa18ea.png)<!-- Debug-pem.crt-der-parse-parseExtension.png -->
i.e. [`addExtension(NID_basic_constraints, "CA:FALSE,pathlen:0")`](https://github.com/aither64/haveclip-core/blob/v0.15.0/src/CertificateGeneratorThread.cpp#L119) adds only `pathlen:0` (without `CA:FALSE`)!

This can also be seen by inspecting the generated cert using these tools ([jsRsaSign Online Tools](https://github.com/kjur/jsrsasign/wiki/jsrsasign-Online-Tools)):

- [ASN.1 Dumper](https://kjur.github.io/jsrsasign/tool/tool_asn1dumper.html) → `INTEGER 00`
- Lapo Luchini: [asn1js](http://lapo.it/asn1js/) → `INTEGER 0`
- [Certificate Viewer](https://kjur.github.io/jsrsasign/tool/tool_certview.html) → fail (see in JS console) **"basicConstraints parse error"** in ["x509-1.1.js":`getExtBasicConstraints()`](https://github.com/kjur/jsrsasign/blob/8.0.15/src/x509-1.1.js#L483-L521)

**Note:** More test certs can be generated [here](https://kjur.github.io/jsrsasign/tool/tool_ca.html) (Basic Constraints: exists[x] critical[x] cAflag[ ] pathLen[0]).

Why "CA:FALSE,pathlen:0" ⇒ `pathlen:0` (without `CA:FALSE`)? And why did OpenSSL allow the generation of invalid certs?

- [RFC 5280, page 135](https://tools.ietf.org/html/rfc5280#page-135) (look for "DEFAULT omit")
- [OpenSSL v1.1.1 — "x509v3_config" file manpage: Basic Constraints](https://www.openssl.org/docs/man1.1.1/man5/x509v3_config.html#Basic-Constraints)
- https://github.com/openssl/openssl/issues/11819#issuecomment-631474930
  > You can use OpenSSL to make invalid certificates, yes. That is useful to be a testing tool.
- [groups.google.com/g/mailing.openssl.users/c/wQgX0jG41zc/m/SI4ERMfpHQAJ](https://groups.google.com/g/mailing.openssl.users/c/wQgX0jG41zc/m/SI4ERMfpHQAJ)  
  (Dr Stephen N. Henson. OpenSSL project core developer.)
- https://github.com/openssl/openssl/pull/11463
- https://github.com/openssl/openssl/issues/11456#issuecomment-607460998

More details about this case, I posted there: https://github.com/pyca/cryptography/issues/3856#issuecomment-636338703 .

…Apple (Apache) also has this issue:
> basicConstraints = CA:false,pathlen:0
> — [opensource.apple.com/source/apache_mod_ssl/…/cca.sh](https://opensource.apple.com/source/apache_mod_ssl/apache_mod_ssl-690/mod_ssl/pkg.contrib/cca.sh.auto.html)

**Note:** HaveClip: [`Settings::loadCertificate()`](https://github.com/aither64/haveclip-core/blob/v0.15.0/src/Settings.cpp#L739) —{[`m_certificate`](https://github.com/aither64/haveclip-core/blob/v0.15.0/src/Settings.h#L235)}—> _[`QSslSocket::setLocalCertificate()`](https://doc.qt.io/qt-5.12/qsslsocket.html#setLocalCertificate)_ in [`Communicator::Communicator()`](https://github.com/aither64/haveclip-core/blob/v0.15.0/src/Network/Communicator.cpp#L41).

[:question: Question ⤏](https://github.com/aither64/haveclip-core/commit/66fd7bbda410a1917cf8fc4a4334583132cc4618#r52421208 "haveclip-core/src/CertificateGeneratorThread.cpp:122 (v0.15.0)")
____________________________________
And for [HaveClip v0.13.0 (Windows)](https://secure.havefun.cz/~aither/pub/releases/haveclip/haveclip-desktop-0.13.0-win32.zip), I made a binary patch. More precisely, the patch is not for HaveClip itself (the issue is not [here](https://github.com/aither64/haveclip-core/blob/v0.13.0/src/CertificateGenerator.cpp#L58-L71)), but for [Q̱C̱A̱](https://api.kde.org/qca/html/ "Qt Cryptographic Architecture"):
- "[libqca-ossl_patch.1337](https://github.com/aither64/haveclip-core/files/6682725/libqca-ossl_patch.1337.txt "Currently, GitHub doesn't support '.1337' attachments directly")*.txt*" <sup>remove the *".txt"* extension</sup> — the patch itself (["Win 1337 Apply Patch" tool](https://github.com/Deltafox79/Win_1337_Apply_Patch/releases))  
  **Note:** The patched "libqca-ossl.dll" [M̱Ḏ5̱](# "certutil -hashfile libqca-ossl.dll MD5") [hash](https://samsclass.info/126/proj/pDC14-256bin.htm): `cad5355acfb314113a637f7e54732de4`.
- "[libqca-ossl.dll.7z](https://github.com/aither64/haveclip-core/files/6682730/libqca-ossl.dll.7z.zip "Currently, GitHub doesn't support '.7z' attachments directly")*.zip*" <sup>remove the *".zip"* extension</sup> — contains the already patched "crypto/libqca-ossl.dll"

<details><summary>About the patch and How I made it…</summary>

**At first**, I delved into the source code looking for the **"pathlen"**:

- HaveClip: [`CertificateGenerator::generateCertificate()`](https://github.com/aither64/haveclip-core/blob/v0.13.0/src/CertificateGenerator.cpp#L56)
  - [`QCA::CertificateInfo info;`](https://github.com/aither64/haveclip-core/blob/v0.13.0/src/CertificateGenerator.cpp#L60)
    - [qca_cert.h] [`typedef QMultiMap<CertificateInfoType, QString> CertificateInfo;`](https://api.kde.org/qca/html/qca__cert_8h_source.html#l00524) ([doc](https://api.kde.org/qca/html/namespaceQCA.html#ad037d51df6abf16726cc85757df10db6)) ⇒ *fail*
  - [`QCA::CertificateOptions opts;`](https://github.com/aither64/haveclip-core/blob/v0.13.0/src/CertificateGenerator.cpp#L58)
    - [qca_cert.h] doc: [`QCA::CertificateOptions` public member functions](https://api.kde.org/qca/html/classQCA_1_1CertificateOptions.html#pub-methods): [`pathLimit()`](https://api.kde.org/qca/html/classQCA_1_1CertificateOptions.html#a35aea3cd787ada6ddd50d8777573c436), [`setAsCA(int pathLimit=8)`](https://api.kde.org/qca/html/classQCA_1_1CertificateOptions.html#a9a5ee39b0d7779bfff2bb62afd891297), [`setAsUser()`](https://api.kde.org/qca/html/classQCA_1_1CertificateOptions.html#ac049b990901f56379702cdb2e5b92ef4)
      - [qca_cert.cpp] [`CertificateOptions::setAsUser()`](https://code.woboq.org/kde/kdesupport/qca/src/qca_cert.cpp.html#_ZN3QCA18CertificateOptions9setAsUserEv) ([KDE‑git](https://invent.kde.org/libraries/qca/-/blob/v2.3.2/src/qca_cert.cpp#L1225-1229))  
        ```cpp
        d->isCA = false;
        d->pathLimit = 0;
        ```
      - [qca_cert.cpp] [`CertificateOptions::pathLimit()`](https://code.woboq.org/kde/kdesupport/qca/src/qca_cert.cpp.html#_ZNK3QCA18CertificateOptions9pathLimitEv) ([KDE‑git](https://invent.kde.org/libraries/qca/-/blob/v2.3.2/src/qca_cert.cpp#L1157-1160)) — [uses](https://code.woboq.org/data/symbol.html?root=../kde/&ref=_ZNK3QCA18CertificateOptions9pathLimitEv#uses):
        - [plugins/qca-ossl/qca-ossl.cpp] [`opensslQCAPlugin::MyCertContext::createSelfSigned()`](https://code.woboq.org/kde/kdesupport/qca/plugins/qca-ossl/qca-ossl.cpp.html#_ZN16opensslQCAPlugin13MyCertContext16createSelfSignedERKN3QCA18CertificateOptionsERKNS1_11PKeyContextE): [`ex = new_basic_constraints(opts.isCA(), opts.pathLimit());`](https://code.woboq.org/kde/kdesupport/qca/plugins/qca-ossl/qca-ossl.cpp.html#3360) ([KDE‑git](https://invent.kde.org/libraries/qca/-/blob/v2.3.2/plugins/qca-ossl/qca-ossl.cpp#L3456))
          - [`opensslQCAPlugin::new_basic_constraints()`](https://code.woboq.org/kde/kdesupport/qca/plugins/qca-ossl/qca-ossl.cpp.html#_ZN16opensslQCAPluginL21new_basic_constraintsEbi) ([KDE‑git](https://invent.kde.org/libraries/qca/-/blob/v2.3.2/plugins/qca-ossl/qca-ossl.cpp#L359-369)) ⇒ [**there you are**](https://invent.kde.org/libraries/qca/-/blob/v2.3.2/plugins/qca-ossl/qca-ossl.cpp#L363-364)

```cpp
static X509_EXTENSION *new_basic_constraints(bool ca, int pathlen)
{
    BASIC_CONSTRAINTS *bs = BASIC_CONSTRAINTS_new();
    bs->ca                = (ca ? 1 : 0);
    bs->pathlen           = ASN1_INTEGER_new();
    ASN1_INTEGER_set(bs->pathlen, pathlen);

    X509_EXTENSION *ex = X509V3_EXT_i2d(NID_basic_constraints, 1, bs); // 1 = critical
    BASIC_CONSTRAINTS_free(bs);
    return ex;
}
```
That is, to use it only with HaveClip, it is enough to delete two lines:
```cpp
static X509_EXTENSION *new_basic_constraints(bool ca, int pathlen)
{
    BASIC_CONSTRAINTS *bs = BASIC_CONSTRAINTS_new();
    bs->ca                = (ca ? 1 : 0);

    X509_EXTENSION *ex = X509V3_EXT_i2d(NID_basic_constraints, 0, bs); // 0 = not critical
    BASIC_CONSTRAINTS_free(bs);
    return ex;
}
```
**Note:** I also made it "not critical" (`0`).

The important thing here is to make sure that `BASIC_CONSTRAINTS_new()` initializes `BASIC_CONSTRAINTS::pathlen` to zero:

- [`BASIC_CONSTRAINTS_new()` man page](https://man.openbsd.org/BASIC_CONSTRAINTS_new.3#BASIC_CONSTRAINTS_new)
- [openssl/x509v3.h] `BASIC_CONSTRAINTS_new()` ← [`DECLARE_ASN1_FUNCTIONS(BASIC_CONSTRAINTS)`](https://code.woboq.org/kde/include/openssl/x509v3.h.html#507)
  - [openssl/asn1.h] `DECLARE_ASN1_FUNCTIONS()`: "[Declare ASN1 functions: the implement macro in in asn1t.h](https://code.woboq.org/kde/include/openssl/asn1.h.html#300)"
    - [openssl/asn1t.h] `IMPLEMENT_ASN1_FUNCTIONS()`: "[Macro to implement standard functions in terms of ASN1_ITEM structures](https://github.com/openssl/openssl/blob/OpenSSL_1_0_1/crypto/asn1/asn1t.h#L819)"  
      **Note:** But I couldn't find the `IMPLEMENT_ASN1_FUNCTIONS(BASIC_CONSTRAINTS)`.
      - … [`IMPLEMENT_ASN1_ALLOC_FUNCTIONS_fname()`](https://github.com/openssl/openssl/blob/OpenSSL_1_0_1/crypto/asn1/asn1t.h#L844-L848): [`ASN1_item_new()` man page](https://man.openbsd.org/ASN1_item_new.3#ASN1_item_new)

<details><summary>The general patch of source code could be like this…</summary>

```cpp
static X509_EXTENSION *new_basic_constraints(bool ca, int pathlen)
{
    BASIC_CONSTRAINTS *bs = BASIC_CONSTRAINTS_new();
    bs->ca                = (ca ? 1 : 0);

    if (ca) {
        bs->pathlen       = ASN1_INTEGER_new();
        ASN1_INTEGER_set(bs->pathlen, pathlen);
    }

    X509_EXTENSION *ex = X509V3_EXT_i2d(NID_basic_constraints, (ca ? 1 : 0), bs);
    BASIC_CONSTRAINTS_free(bs);
    return ex;
}
```
</details>

**Then** I tackled the binary:

1. `new_basic_constraints()` is in "crypto/libqca-ossl.dll" ("plugins/qca-ossl/qca-ossl.cpp"), but it is not an exported function (it’s absent in the [Export Table directory](https://docs.microsoft.com/en-us/windows/win32/debug/pe-format#optional-header-data-directories-image-only) / [Tables](https://docs.microsoft.com/en-us/windows/win32/debug/pe-format#the-edata-section-image-only)" of the dll) → take a look at `BASIC_CONSTRAINTS_new()` ("libeay32.dll") — this is an exported function, and [it is used only in `new_basic_constraints()`](https://code.woboq.org/data/symbol.html?root=../kde/&ref=BASIC_CONSTRAINTS_new#uses)
2. attach a debugger to HaveClip
3. in the debugger, set a breakpoint on `BASIC_CONSTRAINTS_new()`
4. in HaveClip, run the certificate generation
5. when the debugger stops at the breakpoint — go [down](https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/calls-window#calls-window) ([u](https://www.cse.unsw.edu.au/~learn/debugging/modules/gdb_call_stack/#up)[p](https://sourceware.org/gdb/current/onlinedocs/gdb/Selection.html#index-up)) the call stack (from "libeay32.dll" to "libqca-ossl.dll") → here will be **the body of the `new_basic_constraints()` function**
6. set a breakpoint at the beginning of the `new_basic_constraints()` function
7. remove the unwanted part by filling it with `NOP`, and change the argument of the `X509V3_EXT_i2d()` function from `1` (critical) to `0` (not critical)
8. save the patch, test the changes (take a look at the generated certificate, …), patch the "libqca-ossl.dll" file
9. detach the debugger from HaveClip

How to do this in [x32dbg](https://github.com/x64dbg/x64dbg#readme "x64dbg"):

1. (optional) beforehand, in the "Export Table", I looked at the address of `BASIC_CONSTRAINTS_new`: `D3AE0` ([Ṟ](https://en.wikipedia.org/wiki/COFF?&oldid=1020645656#Relative_virtual_address "Relative virtual address")[V̱](https://en.wikibooks.org/wiki/X86_Disassembly/Windows_Executable_Files?oldid=3834245#Relative_Virtual_Addressing_\(RVA\) "Relative virtual address")[A̱](https://docs.microsoft.com/en-us/windows/win32/debug/pe-format "Relative virtual address"))
2. [x32dbg] <kbd><kbd>Alt</kbd>+<kbd>A</kbd></kbd> — ["File" menu > Attach](https://help.x64dbg.com/en/latest/gui/menus/File.html#attach)
3. [x32dbg] [there are several ways to go to the dll’s exported function in the disassembler](https://help.x64dbg.com/en/latest/introduction/Input.html#dll-exports) (not all of them work in older versions of x32dbg) and set the breakpoint:
   - [CPU Tab > Disassembler] <kbd><kbd>Ctrl</kbd>+<kbd>G</kbd></kbd> — context menu: Go to > Expression:
     - `BASIC_CONSTRAINTS_new`
     - `libeay32:BASIC_CONSTRAINTS_new`
     - `libeay32:$D3AE0` (RVA)
     
     <kbd>F2</kbd> — context menu: Breakpoint > Toggle
   - [Symbols tab] "libeay32.dll": `BASIC_CONSTRAINTS_new` → <kbd>F2</kbd> — context menu: Toggle Breakpoint
   - [Symbols tab] "libeay32.dll" → <kbd>Enter</kbd> — context menu: Follow in Disassembler
     - [CPU Tab > Disassembler] <kbd><kbd>Ctrl</kbd>+<kbd>G</kbd></kbd>:
       - `:BASIC_CONSTRAINTS_new`
       - `BASIC_CONSTRAINTS_new`
       
       <kbd>F2</kbd>
4. [HaveClip] Settings > "Security" tab: "Generate new private key and certificate" button → Ok (overwrite)
5. [x32dbg] there are also several ways to go down the call stack:
   - [CPU Tab > Disassembler]:
     1. <kbd><kbd>Ctrl</kbd>+<kbd>F9</kbd></kbd> — toolbar (or "Debug" menu): Execute till return
     2. <kbd>F7</kbd> — toolbar (or "Debug" menu): Step into
     
   - [Call Stack tab]:
     1. context menu: "[Show suspected call stack frame](https://help.x64dbg.com/en/latest/gui/views/CallStack.html)"
     2. several options:
        - jump to the **body** of the `new_basic_constraints` function: top entry → context menu: Follow To <sup>entry: "return **to** … from …"</sup>
        - jump to the **beginning** of the `new_basic_constraints` function: second entry from the top → context menu: Follow From <sup>entry: "return to … **from** …"</sup>
6. [x32dbg: CPU Tab > Disassembler] go to the **beginning** of the `new_basic_constraints` function (the address should be as follows: `libqca-ossl:$1A70` (RVA)) → <kbd>F2</kbd>  
   **Note:** Also, I labeled this address as `new_basic_constraints`: <kbd>:</kbd> — context menu: Label > Label Current Address
7. [x32dbg: CPU Tab > Disassembler]:
   - remove the unwanted part by filling it with `NOP`:
     1. select RVAs: `$1A92`..`$1AA1`
     2. <kbd><kbd>Ctrl</kbd>+<kbd>9</kbd></kbd> — context menu: Fill with NOPs → Ok
   - change the argument from `1` (critical) to `0` (not critical):
     1. go to `$1AAA` (RVA)
     2. <kbd>Space bar</kbd> or [~~double‑click~~](https://github.com/x64dbg/x64dbg/pull/2398) <sup>["Options" menu > Preferences > "Disasm" tab: "Assemble instruction on double-click"](https://github.com/x64dbg/x64dbg/pull/2607) (x64dbg/x64dbg#1672 → x64dbg/x64dbg#2444)</sup> — context menu: Assemble: `mov dword ptr ss:[esp+0x4], 0x0`, Keep Size
8. [x32dbg: CPU Tab > Disassembler]: <kbd><kbd>Ctrl</kbd>+<kbd>P</kbd></kbd> — context menu: Patches (or "File" menu > Path File…)
   - save the patch — "Export" button
   - save the patched "libqca-ossl.dll" file — "Patch File" button
9. [x32dbg] <kbd><kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>F2</kbd></kbd> — ["File" menu > Detach](https://help.x64dbg.com/en/latest/gui/menus/File.html#detach)

**Note:** Oh yes, I also put an unconditional jump at the beginning of the `NOP`s — with so many `NOP`s, there is a reason to do this (regardless of [ḆṮḆ pollution](https://blog.cloudflare.com/branch-predictor/ "Branch Target Buffer")). Or, it is possible to simply lift the "tail" of the function up, after making sure that an optimizing compiler has not made a `jmp` in another function to the "tail" of this function (for the sake of space saving with the same "tails" of both functions).
</details>

## Propagate `X509V3_EXT_conf_nid(,,, const char *value)` (const type qualifier) to its wrapper `CertificateGeneratorThread::addExtension(, char *value)`

```cpp
bool CertificateGeneratorThread::addExtension(int nid, char *value)
{
	...
	if (!(ex = X509V3_EXT_conf_nid(NULL, &ctx, nid, value))) // value is `const char *`
		return false;
	...
}
```
**Note:** full function signature is [`X509V3_EXT_conf_nid(LHASH_OF(CONF_VALUE) *conf, X509V3_CTX *ctx, int ext_nid, const char *value)`](https://github.com/openssl/openssl/blob/OpenSSL_1_1_1g/include/openssl/x509v3.h#L575-L577) ([since](https://github.com/openssl/openssl/blame/OpenSSL_1_1_1g/include/openssl/x509v3.h#L575-L577) openssl/openssl#1074).
**Note:** See also "What is the standard API for adding X509 certificate extension?" (openssl/openssl#11706).

This will also remove the warning "ISO C++11 does not allow conversion from string literal to 'char *'" on `addExtension(NID_basic_constraints, "CA:FALSE")`.

## Correct the validity period (notBefore..notAfter) of a generated certificate to indicate that HaveClip ignores it

… by reducing it from 10 years to 1 sec.

`notAfter` (expiration date) is used to avoid inflating the revocation list — if in the time interval from `notBefore` to `notAfter`, the certificate was revoked (added to the revocation list) then after `notAfter` it can be removed from the revocation list.

**Note:** `notAfter` is also used to reduce [_the load on the key_ (key lifetime)](http://cryptowiki.net/index.php?title=Symmetric_key_management&oldid=8357#Planned_rekeying) ([free translation from Russian](https://translate.google.com/translate?sl=ru&tl=en&u=https://habr.com/en/company/dcmiran/blog/506026/%23comment_21743104)): 
> In addition to the case of a private key leak, there is a problem with _the load on the key_. Exaggerated: usually only the document hash is signed, and the hash function values are finite. So it turns out that, over time, a [hypothetical Eve](https://en.wikipedia.org/wiki/Alice_and_Bob?oldid=1002381852#Cast_of_characters) will learn how to sign more and more hashes, therefore, the probability that these hashes will include the hash of the document Eve needs will increase.
> 
> […]
> 
> In the case of asymmetric cryptography, there are even more obvious problems. For example, in [ElGamal’s encryption system](https://en.wikipedia.org/wiki/ElGamal_encryption), security is provided by the (supposed) difficulty of computing discrete logarithms — it is difficult to compute a private key from a public one. These calculations are difficult but not impossible — albeit in a long (at this stage of technology development), but finite time. And the key pair cannot be used longer than this time.

But protocols that transmit a public key only during the initial pairing of devices are less affected by this (Eve will have to catch the moment of pairing the devices to [sniff](http://intercepter-ng.blogspot.com/2017/02/intercepter-ng-10-anniversary-edition.html) the public key).

<details><summary>Subsequent data transmission sessions can, <strong>in a simplified form</strong>, start like this…</summary>

**Note:** It [us](https://en.wikipedia.org/wiki/Transport_Layer_Security?oldid=1001897409#Description)[e](https://tools.ietf.org/html/rfc5246#appendix-F.1.1.3)[s](https://tools.ietf.org/html/rfc5246#section-8.1) [Diffie-Hellman](https://en.wikipedia.org/wiki/Diffie–Hellman_key_exchange?oldid=996500999#Cryptographic_explanation) [key exchange](https://upload.wikimedia.org/wikipedia/commons/thumb/1/13/Diffie-Hellman-Schlüsselaustausch.svg/800px-Diffie-Hellman-Schlüsselaustausch.svg.png) to provide [for](https://en.wikipedia.org/wiki/Diffie–Hellman_key_exchange?oldid=996500999#Forward_secrecy)[ward](https://en.wikipedia.org/wiki/Transport_Layer_Security?oldid=1001897409#Forward_secrecy) [secrecy](https://tools.ietf.org/html/rfc5246#appendix-F.1.1.2).
```
                                   Data Sender]       [Data Receiver

"Sender name" or hash("Sender's public key"); |       |
                    Diffie-Hellman: g, p, A ; |       |
  ↳ [encryption using Receiver's public key]  | ----> | Identification.

                                              |       | Add this "random string"
                                              |       |  authentication string to your data;
                                              |       | Diffie-Hellman: B;
   Diffie-Hellman: calc a session shared Key. | <---- | [encryption using Sender's public key] ↲

                Data: "random string"|<data>; |       |
  ↳ [encryption using s - session shared Key] | ----> | Authentication:
                                              |       |  "random string" == "random string"
                                              |       | Reading the <data>...
                                                      
```
**Note:** The current initial device pairing protocol used by the program is vulnerable to a MitM attack ([see comment to "haveclip-core/doc/protocol.md#verification" ⤏](https://github.com/aither64/haveclip-core/commit/cfbd2c687d4a736b28b03a8b7ff5af8e16b789f0#r52421290 "haveclip-core/doc/protocol.md:58 (v0.15.0)")).
</details>

**Note:** TLS (and accordingly HaveClip v0.15) [sends](https://www.wireshark.org) the public key (in the certificate) [at the start](https://en.wikipedia.org/wiki/Transport_Layer_Security?oldid=1001897409#Client-authenticated_TLS_handshake) of each new data transmission session.

Since HaveClip does not check the validity period of an incoming certificate ([Sender](https://github.com/aither64/haveclip-core/blob/v0.15.0/src/Network/Sender.cpp#L97) and [Receiver](https://github.com/aither64/haveclip-core/blob/v0.15.0/src/Network/Receiver.cpp#L50) use the [`QSslSocket::QueryPeer` mode](https://doc.qt.io/qt-5.12/qsslsocket.html#PeerVerifyMode-enum), and the validity dates are not checked anywhere in HaveClip code) and does not use the revocation list, `notAfter` can be set to `now + 1` (or according to the standard: [99991231235959Z](https://tools.ietf.org/html/rfc5280#section-4.1.2.5)).

Why did I choose 1 second?

- 99991231235959Z — used in the cases described in [RFC 5280](https://tools.ietf.org/html/rfc5280#section-4.1.2.5)
- 1 sec — temporary certificate
- 0 sec — applications that use this certificate ignore the validity period

It would be logical to use 0 sec (`notBefore == notAfter`). But although `notAfter` is inclusive `[notBefore, notAfter]` by the standard, some implementations may mistakenly process it as exclusive `[notBefore, notAfter)`, which can lead to an error. Therefore, 1 sec is a more resistant value to errors in implementations of the standard than 0 sec.

## SHA-1 Sunset

Since version [1.2.1 of "Baseline Requirements for the Issuance and Management of **Publicly**-Trusted Certificates"](https://cabforum.org/wp-content/uploads/BRv1.2.1.pdf) ([Ballot 118](https://cabforum.org/2014/10/16/ballot-118-sha-1-sunset/) — 16 October 2014; page 14):
> **9.4.2 SHA‐1 Validity Period**
> 
> Effective 1 January 2016, CAs MUST NOT issue any new Subscriber certificates or Subordinate CA certificates using the SHA-1 hash algorithm. CAs MAY continue to sign certificates to verify OCSP responses using SHA1 until 1 January 2017. This Section 9.4.2 does not apply to Root CA or CA cross certificates. CAs MAY continue to use their existing SHA-1 Root Certificates. SHA-2 Subscriber certificates SHOULD NOT chain up to a SHA-1 Subordinate CA Certificate.
> 
> Effective 16 January 2015, CAs SHOULD NOT issue Subscriber Certificates utilizing the SHA-1 algorithm with an Expiry Date greater than 1 January 2017 because Application Software Providers are in the process of deprecating and/or removing the SHA-1 algorithm from their software, and they have communicated that CAs and Subscribers using such certificates do so at their own risk.

Details:

- [Announcing the first SHA1 collision](https://security.googleblog.com/2017/02/announcing-first-sha1-collision.html) (23 February 2017 — CWI Institute in Amsterdam & Google)
- [Q&A](https://shattered.it)
- [Paper](https://shattered.it/static/shattered.pdf "is a revised https://eprint.iacr.org/2017/190.pdf") "[The first collision for full SHA-1](https://ia.cr/2017/190)" (GPUs: NVIDIA Tesla K80, K40/GTX 970 and K20)

**Note:** It is a "[collision attack](https://en.wikipedia.org/wiki/Collision_attack)" (`hash(cert1) == hash(cert2)`, both certificates are generated by one person), not a "[second-preimage attack](https://en.wikipedia.org/wiki/Preimage_attack?oldid=1002732721#Applied_preimage_attacks)" (`hash(cert_My) == hash(cert_Chuck)`, [Chuck](https://en.wikipedia.org/wiki/Alice_and_Bob?oldid=1002381852#Cast_of_characters)):

> In general, a collision attack is easier to mount than a preimage attack, as it is not restricted by any set value _[cert]_ (any two values _[certs]_ can be used to collide).

See also "[What is the difference between a second preimage attack and a collision attack?](https://cstheory.stackexchange.com/questions/585/what-is-the-difference-between-a-second-preimage-attack-and-a-collision-attack)".

[Repositories](https://marc-stevens.nl/research/#software):

- [MD5 & SHA-1 collision file format exploitations](https://github.com/corkami/collisions#readme)
- [GPU Framework for SHA-1 collisions](https://github.com/cr-marcstevens/sha1_gpu_nearcollisionattacks#readme)
- [Library and command line tool to detect SHA-1 collisions in files](https://github.com/cr-marcstevens/sha1collisiondetection)

Now, keeping in mind [that](https://tools.ietf.org/html/rfc5280#section-4.1.1.3):
> By generating this signature, a CA certifies the validity of the information in the tbsCertificate field. In particular, the CA _certifies the binding between the public key material and the subject of the certificate_.

⇒ [Using](https://tools.ietf.org/html/rfc5280#section-4.1.1.3) a strong [hashing algorithm](https://tools.ietf.org/html/rfc5280#section-4.1.1.2) for the certificate data ([`tbsCertificate`](https://tools.ietf.org/html/rfc5280#section-4.1.1.1) [field](https://tools.ietf.org/html/rfc5280#section-4.1)) is not necessary for HaveClip:

- Of all the certificate fields, only the public key field (`subjectPublicKeyInfo`) is used by HaveClip. Even "[Name](https://github.com/aither64/haveclip-core/blob/v0.15.0/src/Network/ConnectionManager.cpp#L282)" is not [taken from the certificate](https://github.com/aither64/haveclip-desktop/blob/v0.15.0/haveclip-desktop/src/SettingsDialog.cpp#L228). 
- HaveClip is a "~~[**Privately**-](https://www.ssl.com/article/private-vs-public-pki-building-an-effective-plan/#user-content-public-key-infrastructure)[Trusted](https://www.ibm.com/support/knowledgecenter/ssw_ibm_i_73/rzahu/rzahurzahu4afinternetvsprivcert.htm)~~ [Self-Signed](https://en.wikipedia.org/wiki/Self-signed_certificate?oldid=984169041#Security_issues) Certificates Issuer", not a "**Publicly**-Trusted Certificates Issuer".

Nevertheless, I have upgraded the algorithm to [SHA2](https://public-inbox.org/git/20180609224913.GC38834@genre.crustytoothpaste.net/ "Hash algorithm performance analysis")[56](https://public-inbox.org/git/CA+55aFx876XPwdSqRsKDk+Vo4pD-0wVRx=E+SAN6JiZKWUMrHg@mail.gmail.com/ "Reply from Linus Torvalds") (it is also used by default in automatically generated RDP <sup>[Network Level Authentication](http://web.archive.org/web/20110707080658/http://blogs.msdn.com/b/rds/archive/2008/07/21/configuring-terminal-servers-for-server-authentication-to-prevent-man-in-the-middle-attacks.aspx)</sup> [certificates](http://lapo.it/asn1js/#MIICuzCCAaOgAwIBAgIB_zANBgkqhkiG9w0BAQsFADAOMQwwCgYDVQQDDANEZXYwHhcNMjAwMTA5MTgwNjA4WhcNMjAwNzEwMTgwNjA4WjAOMQwwCgYDVQQDDANEZXYwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDiqLDw9azs-mecLYFQSgNFzBcXymrxdPX_cdzdy5QnBf-i015-v8Giavd20zQREs3cOt6kJe-7MRTkVwlUNQHewj6kW2OMsFcP_Mma4vcB-D3Un2nv34Ob7jdxHrC4rLBUnHkMkh2zAXqhAMPOHC7z13ZXnHTZpcH0up1eQ_CI7R5Hmz_EdeABKX6GoN1Uv2Euh3eIZr2dXtwSUJtyXxRVc08mdAB9qIprMX6EJ2X-zKsiHQoJnmimCCxMmJujyoVcGYbg-RPlhuEcTXXBgogvBkVK9n2J11E9ArcK2AWIGddtXBTm3ru2f2kyLMeDKmCx8Gh6jIGulO5zh6BIKmOxAgMBAAGjJDAiMAsGA1UdDwQEAwIEMDATBgNVHSUEDDAKBggrBgEFBQcDATANBgkqhkiG9w0BAQsFAAOCAQEAxqRc3GBh6MahXT-BrdYbNkBNfCxXkAUSbUTEtd4XhIa9GspQjvzbXakRBvBxxZmU8mNum5zoyZ73MQ2XY4vQ10rddan0KO3WPETO_aPo43sC4_NH6DqvAARdUptDozvhMFtR_otykSE7KX66pIPJbGqoOH4v3GB5LmEQG8fOVA68LxsTE6vHzk5lmSxnIWvusSjZBU5UXUaWOwSwIo4djckhesvyA9B5H93Wd1UXqMKSkTs0WelnpBhLze1vpRBgD_gKeinVeZtFjVda91zuk9-r8fpmAUiwhPWLnK8SLQp_L5_Lam2quqC9Jx796W0rscqxQ0dwlAtOai2YmCQlPg) now).

## [not here] Sign the .app <sup>here: show full error string</sup>

The `HaveClip.app` works only on first run after new (unique) build — can't access the client cert/key in keychain (Secure Transport automatically puts it there).

The "**Do you want the application “_app_” to accept incoming network connections?**" firewall message every time the _app_ starts is also fixed there.

Issue: aither64/haveclip-desktop#3
PR: aither64/haveclip-desktop#4

[:question: ~~Question~~ Comment ⤏](https://github.com/aither64/haveclip-desktop/commit/816c4856d8c0a8e9925e26673e9f46860c6adc54#r52421338 "haveclip-desktop/utils/deploy_mac.sh:6 (v0.15.0)")
[:question: ~~Question~~ Comment ⤏](https://github.com/aither64/haveclip-desktop/commit/816c4856d8c0a8e9925e26673e9f46860c6adc54#r52421391 "haveclip-desktop/utils/deploy_mac.sh:36 (v0.15.0)")

### `Communicator::onError(SocketError)`: Show full error string

Consider the HaveClip output in aither64/haveclip-desktop#3 for example. 
Before:
```
Connection error QAbstractSocket::SocketError(13)  (0)
```
After:
```
Connection error QAbstractSocket::SocketError(13)  (0):  "SSLHandshake failed: -25293"
```

This can be tested with:
```bash
/usr/local/opt/openssl/bin/openssl s_client -connect <peer0: HaveClip listen on IP>:9999 -tls1 -key haveclip-peer1.key -cert haveclip-peer1.crt -CAfile haveclip-peer0.crt -x509_strict
```
(optionally add: `-msg` or `-state`):
- [stackoverflow.com/questions/25592467/failed-ssl-handshake-with-ssl-server-written-on-qt-5-2-1](https://stackoverflow.com/questions/25592467/failed-ssl-handshake-with-ssl-server-written-on-qt-5-2-1)
- [www.rabbitmq.com/troubleshooting-ssl.html#sclient-connection](https://www.rabbitmq.com/troubleshooting-ssl.html#sclient-connection) (+ `stunnel`: *HaveClip1*―[TLS]⟶*stunnel*―[unenc]⟶*HaveClip2*)
- [www.openssl.org/docs/man1.1.1/man1/openssl-s_client.html](https://www.openssl.org/docs/man1.1.1/man1/openssl-s_client.html)

## [also not here] Prevent storage of the client cert/key in the "Login" keychain

PR: aither64/haveclip-desktop#4

## Fix crash on launch with an "empty" peer's certificate

Case (steps to reproduce):
**Note:** Before starting, It is better to make a backup of your current HaveClip [config](https://doc.qt.io/qt-5.12/qsettings.html#locations-where-application-settings-are-stored) <sup>([ConfigLocation](https://doc.qt.io/qt-5.12/qstandardpaths.html#StandardLocation-enum))</sup>.

0. Initial state:
   - **Encryption:** None.
   - **Peer0:** macOS Mojave, HaveClip v0.15+ (Qt v5.12.8; OpenSSL v1.1.1g; TLS/SSL backend: Secure Transport).
   - **Peer1:** Windows, [HaveClip v0.13.0](https://secure.havefun.cz/~aither/pub/releases/haveclip/haveclip-desktop-0.13.0-win32.zip) (Qt v4.8.1; OpenSSL v1.0.0d; TLS/SSL backend: OpenSSL).
   - The peers are not paired (i.e. `Settings[Pool.Nodes]` is empty).
1. Pair the peers.  
   *Result:*
   - **Verification:** successfully finished.
   - `Settings[Pool.Nodes.0.Certificate] == `
     - Peer0: `"-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----"`, i.e. 
       ```
       -----BEGIN CERTIFICATE-----
       -----END CERTIFICATE-----
       ```
     - Peer1: `""`.
2. Restart HaveClip on both peers.  
   *Result:*
   - Peer0: **Crash**.
     Program output (in Terminal):
     ```
     ASSERT: "!isEmpty()" in file /…/Qt/5.12.8/clang_64/lib/QtCore.framework/Headers/qlist.h, line 347
     zsh: 'HaveClip.app/Contents/MacOS/Hav…' terminated by signal SIGABRT (Abort)
     ```
     Stack trace from the crash report:
     ```
     Thread 0 Crashed:
     0   libsystem_kernel.dylib        __pthread_kill + 10
     1   libsystem_pthread.dylib       pthread_kill + 284
     2   libsystem_c.dylib             abort + 127
     3   org.qt-project.QtCore         0x109611000 + 99321
     4   org.qt-project.QtCore         QMessageLogger::fatal(char const*, ...) const + 202
     5   org.qt-project.QtCore         qt_assert(char const*, char const*, int) + 77
     6   com.yourcompany.HaveClip      QList<QSslCertificate>::first() + 62 (qlist.h:347)
     7   com.yourcompany.HaveClip      Node::load(QSettings*, unsigned int) + 1284 (Node.cpp:158)
     8   com.yourcompany.HaveClip      Settings::loadNodes() + 498 (Settings.cpp:639)
     9   com.yourcompany.HaveClip      Settings::load() + 5049 (Settings.cpp:627)
     10  com.yourcompany.HaveClip      Settings::init() + 424 (Settings.cpp:68)
     11  com.yourcompany.HaveClip      HaveClip::HaveClip(QObject*) + 296 (HaveClip.cpp:47)
     12  com.yourcompany.HaveClip      HaveClip::HaveClip(QObject*) + 29 (HaveClip.cpp:117)
     13  com.yourcompany.HaveClip      main + 542 (Main.cpp:72)
     14  libdyld.dylib                 start + 1
     ```
   - Peer1: **Ok**.

**Note:** on macOS, after restoring HaveClip [config](https://doc.qt.io/qt-5.12/qsettings.html#locations-where-application-settings-are-stored) from the backup, it is needed to [re‑read (sync the cache) the ".plist" file](http://hints.macworld.com/article.php?story=20130908042828630) with the `defaults read cz.havefun.HaveClip` command.
[:question: ~~Question~~ Suggestion ⤏](https://github.com/aither64/haveclip-desktop/commit/896ad0d4ca198701333e667bd8e71f2a0ad7cfba#r52421806 "haveclip-desctop/src/Main.cpp:36 (v0.15.0)")

The same will happen in the slightly different case:

0. Initial state:
   - Encryption: **TLS**.
   - The peers are **paired**.
1. Set encryption to None.
2. Re‑pair the peers (the "New identity verification" button in the "Edit device"←"NodeDialog.ui" dialog box).
   …
3. Restart HaveClip on both peers.
   …
